### PR TITLE
cloneElement Patch

### DIFF
--- a/site/web/app/themes/moiraine/assets/js/block-extensions/post-excerpt.js
+++ b/site/web/app/themes/moiraine/assets/js/block-extensions/post-excerpt.js
@@ -79,31 +79,31 @@
         };
     }, 'withInspectorControls');
 
-    // Modify the save function to conditionally wrap the excerpt in a link
-    const modifySaveElement = function(element, blockType, attributes) {
-        if (blockType.name !== 'core/post-excerpt') {
-            return element;
-        }
+    // Add custom class name to the block
+    const withCustomClassName = createHigherOrderComponent((BlockListBlock) => {
+        return (props) => {
+            if (props.name !== 'core/post-excerpt') {
+                return createElement(BlockListBlock, props);
+            }
 
-        if (!attributes.linkToPost) {
-            return element;
-        }
+            const { attributes } = props;
+            const { linkToPost, underlineLink } = attributes;
 
-        // We're in the editor, so we need to add a class to simulate the link
-        // The actual linking happens on the PHP side
-        const className = 'moiraine-linked-excerpt' + (attributes.underlineLink ? ' has-underline' : ' no-underline');
-        
-        // Add our custom class to the existing element
-        if (element && element.props && element.props.className) {
-            return wp.element.cloneElement(element, {
-                className: element.props.className + ' ' + className
+            // Only add custom class if linkToPost is true
+            if (!linkToPost) {
+                return createElement(BlockListBlock, props);
+            }
+
+            // Create the class name based on attributes
+            const className = 'moiraine-linked-excerpt' + (underlineLink ? ' has-underline' : ' no-underline');
+
+            // Add custom class
+            return createElement(BlockListBlock, {
+                ...props,
+                className: props.className ? props.className + ' ' + className : className
             });
-        } else {
-            return wp.element.cloneElement(element, {
-                className: className
-            });
-        }
-    };
+        };
+    }, 'withCustomClassName');
 
     // Register our filters
     addFilter(
@@ -119,8 +119,8 @@
     );
 
     addFilter(
-        'blocks.getSaveElement', 
-        'moiraine/post-excerpt-link-output',
-        modifySaveElement
+        'editor.BlockListBlock',
+        'moiraine/post-excerpt-link-class',
+        withCustomClassName
     );
 })(window.wp);


### PR DESCRIPTION
This pull request introduces several changes to the `post-excerpt` block in the Moiraine theme, focusing on adding custom attributes and modifying the block's behavior both in the editor and on the front end. The most important changes include the addition of custom attributes, modifications to how the block is rendered in the editor, and adjustments to the server-side rendering of the block.

### Enhancements to `post-excerpt` block:

* **Custom Attributes**:
  * Registered two new custom attributes, `linkToPost` and `underlineLink`, for the `core/post-excerpt` block to enable additional customization options.

* **Editor Modifications**:
  * Replaced the `modifySaveElement` function with a higher-order component `withCustomClassName` to add a custom class to the block in the editor based on the new attributes.
  * Updated the filter registration to use the new higher-order component for adding custom classes to the block in the editor.

* **Server-Side Rendering**:
  * Simplified the logic for wrapping the excerpt text in a link by directly modifying the paragraph content within the `moiraine_filter_post_excerpt_block_output` function.